### PR TITLE
Allow using AllItems view instead of default view for Sharepoint lists + change paging size

### DIFF
--- a/python-connectors/sharepoint-online_lists/connector.json
+++ b/python-connectors/sharepoint-online_lists/connector.json
@@ -100,6 +100,14 @@
             "defaultValue": false
         },
         {
+            "name": "use_allitems_view",
+            "label": "Use All Items view",
+            "description": "Use All Items view instead of (maybe filtered) default view",
+            "visibilityCondition": "model.advanced_parameters == true",  
+            "type": "BOOLEAN",
+            "defaultValue": false
+        },
+        {
             "name": "max_workers",
             "label": "Max nb of workers (write mode only)",
             "description": "More workers will speed writing but also randomize items order",

--- a/python-connectors/sharepoint-online_lists/connector.json
+++ b/python-connectors/sharepoint-online_lists/connector.json
@@ -108,6 +108,16 @@
             "defaultValue": false
         },
         {
+            "name": "page_size",
+            "label": "Page size (read mode only)",
+            "description": "No. of rows read from Sharepoint at once",
+            "visibilityCondition": "model.advanced_parameters == true",
+            "type": "INT",
+            "defaultValue": 30,
+            "minI": 30,
+            "maxI": 5000
+        },
+        {
             "name": "max_workers",
             "label": "Max nb of workers (write mode only)",
             "description": "More workers will speed writing but also randomize items order",

--- a/python-connectors/sharepoint-online_lists/connector.py
+++ b/python-connectors/sharepoint-online_lists/connector.py
@@ -26,12 +26,14 @@ class SharePointListsConnector(Connector):
         self.metadata_to_retrieve = config.get("metadata_to_retrieve", [])
         advanced_parameters = config.get("advanced_parameters", False)
         if not advanced_parameters:
+            self.use_allitems_view = False
             self.max_workers = 1  # no multithread per default
             self.batch_size = 100
         else:
+            self.use_allitems_view = config.get("use_allitems_view", False)
             self.max_workers = config.get("max_workers", 1)
             self.batch_size = config.get("batch_size", 100)
-        logger.info("init:advanced_parameters={}, max_workers={}, batch_size={}".format(advanced_parameters, self.max_workers, self.batch_size))
+        logger.info("init:advanced_parameters={}, max_workers={}, batch_size={}, use_allitems_view={}".format(advanced_parameters, self.max_workers, self.batch_size, self.use_allitems_view))
         self.metadata_to_retrieve.append("Title")
         self.display_metadata = len(self.metadata_to_retrieve) > 0
         self.client = SharePointClient(config)
@@ -104,10 +106,14 @@ class SharePointListsConnector(Connector):
     def is_not_last_page(page):
         return "Row" in page and "NextHref" in page
 
-    @staticmethod
-    def get_next_page_query_string(page):
-        ret = page.get("NextHref", "")
+    def get_next_page_query_string(self, page):
+        ret = page.get("NextHref", self.get_view_query_string())
         return ret
+
+    def get_view_query_string(self):
+        if self.use_allitems_view:
+            return self.client.get_list_allitems_view_query(self.sharepoint_list_title)
+        return ""
 
     @staticmethod
     def get_page_rows(page):

--- a/python-lib/sharepoint_client.py
+++ b/python-lib/sharepoint_client.py
@@ -293,7 +293,7 @@ class SharePointClient():
         json_response = response.json()
         views = json_response.get(SharePointConstants.RESULTS_CONTAINER_V2, {"results": []}).get("results", [])
         if len(views) == 1:
-            view_id = response[0]["Id"]
+            view_id = views[0]["Id"]
         else:
             view_id = [
                 v["Id"]


### PR DESCRIPTION
Some of the Sharepoint Lists we want to connect to have multiple views defined. At least on one list, it's `default` view is _filtered_ (i.e. showing only non-completed values). 

To transfer _all_ the list's items (and not only those in the `default` view), we have to figure out the ID of `AllItems.aspx`, which always shows all items of said list.

*Addition*: We also had issues on larger Sharepoint lists taking a long time to load. Therefore a custom page size option has been added as well.

This PR therefore adds/changes the following:

#### python-connectors/sharepoint-online_lists/connector.json:
- additional `advanced` parameter `Use All Items view` (default: `False`)
- additional `advanced` parameter `Page Size` (default: `30` as would be without parameter as well)

#### python-lib/sharepoint_client.py:
- `get_list_allitems_view_url()` to build the URL required to download all available views for a given list
- `get_list_allitems_view_id()` to return a dictionary with `view id` if a non-default view is required
- `get_view_query_string()` to return a combined query string with all relevant parameters.
  - get a `view id` if available (default parameter)
  - use `paging` size if available (default parameter)
  - use query string returned by `NextHref`

#### python-connectors/sharepoint-online_lists/connector.py:
- Adjust `get_next_page_query_string()` to combine `NextHref` with default parameters

If you have any suggestions please let me know.

Best regards,
Richard