### PR TITLE
fix: [sc-196085] [SharePoint online plugin] Rows containing strings longer than 256 chars are silently rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Version 1.1.4](https://github.com/dataiku/dss-plugin-sharepoint-online/releases/tag/v1.1.4) - Feature release - 2024-07-16
 
 - Fix writing when using presets with no root folder defined
+- Limit string length to the 255 characters SharePoint limit
 
 ## [Version 1.1.2](https://github.com/dataiku/dss-plugin-sharepoint-online/releases/tag/v1.1.2) - Bugfix release - 2024-05-28
 

--- a/python-lib/sharepoint_lists.py
+++ b/python-lib/sharepoint_lists.py
@@ -207,6 +207,9 @@ class SharePointListWriter(object):
             )
             if column and structure.get("type") == "date":
                 ret[key_to_use] = dss_to_sharepoint_date(column)
+            elif column and structure.get("type") == "string":
+                # max length of a string on SharePoint is 255
+                ret[key_to_use] = column[:255]
             else:
                 ret[key_to_use] = column
         return ret

--- a/tests/python/integration/test_scenario.py
+++ b/tests/python/integration/test_scenario.py
@@ -53,3 +53,7 @@ def test_run_sharepoint_online_encrypted_certificate_auth(user_dss_clients):
 
 def test_run_sharepoint_online_write_preset_without_root_folder(user_dss_clients):
     dss_scenario.run(user_dss_clients, project_key=TEST_PROJECT_KEY, scenario_id="SC194128NOROOTFOLDERPRESETS")
+
+
+def test_run_sharepoint_online_256_plus_chars_strings(user_dss_clients):
+    dss_scenario.run(user_dss_clients, project_key=TEST_PROJECT_KEY, scenario_id="SC196085_256_CHARS_BUG")


### PR DESCRIPTION
Story details: https://app.shortcut.com/dataiku/story/196085